### PR TITLE
Remove property short name

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -134,7 +134,7 @@ For more information on the conformance implications, see
 Section 3.5, Properties,
 in particular the definition (D35) of an informative property.
 </p>
-<h2>3 The Auto_Spacing Property (as)</h2>
+<h2>3 The Auto_Spacing Property</h2>
 
 <h3>3.1 Property Values</h3>
 <p>


### PR DESCRIPTION
The property short name was removed earlier by the feedback from the UTC, but one reference was left over. This patch removes it.